### PR TITLE
Updates seed.version to 3.8.5 and swagger-jersey to 1.5.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: java
 
-jdk: oraclejdk8
+jdk: openjdk11
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.1.1 (2019-03-26)
+
+* [chg] Update Swagger to 1.5.22
+* [chg] Update Seed to 3.8.5
+
 # Version 2.1.0 (2018-10-18)
 
 * [new] Classes annotated with `SwaggerDefinition` are detected.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+    Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+    Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,18 +14,18 @@
     <parent>
         <groupId>org.seedstack.poms</groupId>
         <artifactId>parent-internal</artifactId>
-        <version>3.4.2</version>
+        <version>3.4.6</version>
     </parent>
 
     <groupId>org.seedstack.addons.swagger</groupId>
     <artifactId>swagger</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
 
     <properties>
-        <seed.version>3.7.3</seed.version>
+        <seed.version>3.8.5</seed.version>
         <compatibility.skip>true</compatibility.skip>
         <bintray.package>swagger-addon</bintray.package>
-        <swagger-jersey.version>1.5.20</swagger-jersey.version>
+        <swagger-jersey.version>1.5.22</swagger-jersey.version>
     </properties>
 
     <build>

--- a/src/main/java/org/seedstack/swagger/BaseReaderListener.java
+++ b/src/main/java/org/seedstack/swagger/BaseReaderListener.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger;
 
 import com.google.inject.Injector;

--- a/src/main/java/org/seedstack/swagger/SwaggerConfig.java
+++ b/src/main/java/org/seedstack/swagger/SwaggerConfig.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger;
 
 import io.swagger.core.filter.SwaggerSpecFilter;

--- a/src/main/java/org/seedstack/swagger/internal/AbstractSwaggerResource.java
+++ b/src/main/java/org/seedstack/swagger/internal/AbstractSwaggerResource.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger.internal;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/org/seedstack/swagger/internal/SwaggerJsonResource.java
+++ b/src/main/java/org/seedstack/swagger/internal/SwaggerJsonResource.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger.internal;
 
 import io.swagger.annotations.ApiOperation;

--- a/src/main/java/org/seedstack/swagger/internal/SwaggerModule.java
+++ b/src/main/java/org/seedstack/swagger/internal/SwaggerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/main/java/org/seedstack/swagger/internal/SwaggerPlugin.java
+++ b/src/main/java/org/seedstack/swagger/internal/SwaggerPlugin.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger.internal;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/org/seedstack/swagger/internal/SwaggerProvider.java
+++ b/src/main/java/org/seedstack/swagger/internal/SwaggerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/main/java/org/seedstack/swagger/internal/SwaggerYamlResource.java
+++ b/src/main/java/org/seedstack/swagger/internal/SwaggerYamlResource.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger.internal;
 
 import io.swagger.annotations.ApiOperation;

--- a/src/main/resources/org/seedstack/swagger/SwaggerConfig.properties
+++ b/src/main/resources/org/seedstack/swagger/SwaggerConfig.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+# Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/test/java/org/seedstack/swagger/Demo.java
+++ b/src/test/java/org/seedstack/swagger/Demo.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger;
 
 import org.seedstack.seed.core.SeedMain;

--- a/src/test/java/org/seedstack/swagger/SwaggerIT.java
+++ b/src/test/java/org/seedstack/swagger/SwaggerIT.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger;
 
 import static io.restassured.RestAssured.expect;
@@ -25,9 +24,9 @@ import org.skyscreamer.jsonassert.JSONAssert;
 @RunWith(SeedITRunner.class)
 @LaunchWithUndertow
 public class SwaggerIT {
-    @Configuration("web.runtime.baseUrl")
+    @Configuration("runtime.web.baseUrlSlash")
     private String baseUrl;
-    @Configuration("web.runtime.port")
+    @Configuration("runtime.web.server.port")
     private int port;
     private static final String SWAGGER_JSON = "{\"swagger\":\"2.0\",\"info\":{\"version\":\"1.0.2\"," +
             "\"title\":\"Test API\"},\"host\":\"localhost:%d\",\"basePath\":\"/context/api\"," +

--- a/src/test/java/org/seedstack/swagger/SwaggerWithoutWebIT.java
+++ b/src/test/java/org/seedstack/swagger/SwaggerWithoutWebIT.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/seedstack/swagger/fixtures/MyApiDefinition.java
+++ b/src/test/java/org/seedstack/swagger/fixtures/MyApiDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/test/java/org/seedstack/swagger/fixtures/MyFilter.java
+++ b/src/test/java/org/seedstack/swagger/fixtures/MyFilter.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger.fixtures;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/seedstack/swagger/fixtures/MyResource.java
+++ b/src/test/java/org/seedstack/swagger/fixtures/MyResource.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger.fixtures;
 
 import io.swagger.annotations.Api;

--- a/src/test/java/org/seedstack/swagger/fixtures/MySurnameBean.java
+++ b/src/test/java/org/seedstack/swagger/fixtures/MySurnameBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/test/java/org/seedstack/swagger/internal/SwaggerProviderTest.java
+++ b/src/test/java/org/seedstack/swagger/internal/SwaggerProviderTest.java
@@ -1,11 +1,10 @@
 /*
- * Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 package org.seedstack.swagger.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2013-2018, The SeedStack authors <http://seedstack.org>
+# Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Change parent-internal from 3.4.2 to 3.4.6
Update license headers
Update CHANGELOG
Bump Version
Update .travis.yml to use openjdk11

Fix integration tests with seed 18.11.3